### PR TITLE
implement byte -> (row group, column) mapper using interval tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "intervaltree"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270bc34e57047cab801a8c871c124d9dc7132f6473c6401f645524f4e6edd111"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2773,7 @@ dependencies = [
  "hdrhistogram",
  "hex",
  "httpmock",
+ "intervaltree",
  "lazy_static",
  "libc",
  "linked-hash-map",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -45,7 +45,6 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 parquet = "25.0.0"
 intervaltree = "0.2.7"
-tokio = { version = "1.24.2", features = ["rt", "macros", "sync"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -44,6 +44,7 @@ tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 parquet = "25.0.0"
+intervaltree = "0.2.7"
 tokio = { version = "1.24.2", features = ["rt", "macros", "sync"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -131,6 +131,7 @@ impl<E: std::error::Error + Send + Sync + 'static> From<PrefetchReadError<E>> fo
             PrefetchReadError::Integrity(e) => err!(libc::EIO, source:e, "integrity error"),
             PrefetchReadError::GetRequestFailed(_)
             | PrefetchReadError::GetRequestTerminatedUnexpectedly
+            | PrefetchReadError::MetadataParsingFailed
             | PrefetchReadError::GetRequestReturnedWrongOffset { .. } => {
                 err!(libc::EIO, source:err, "get request failed")
             }


### PR DESCRIPTION
## Description of change

Added a byte range -> (row group, column) mapper using an interval tree

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

It does not affect the behaviour, we simply have an extra attribute with Parsed Metadata being stored as an interval tree, for easy querying

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
